### PR TITLE
Enhance personal agent with search and help

### DIFF
--- a/personal_ai_agent/README.md
+++ b/personal_ai_agent/README.md
@@ -41,6 +41,8 @@ A GUI window will appear. Click the "Push to Talk" button to issue voice command
 *   **Take Notes:** Say "take a note", and the agent will prompt you for the content. Notes are saved in the `notes/` directory.
 *   **Draft Emails:** Say "draft an email", and the agent will guide you through recipient, subject, and body. Drafts are saved in the `drafts/` directory.
 *   **List Notes:** Say "list my notes", and the agent will show and speak a list of your saved notes.
+*   **Search Notes:** Say "search my notes" and specify a keyword to find notes containing that text.
+*   **Help:** Say "help" to hear a summary of available commands.
 
 ## Speech Recognition
 *   The agent primarily uses CMU Sphinx for offline speech-to-text.

--- a/personal_ai_agent/intent_parser.py
+++ b/personal_ai_agent/intent_parser.py
@@ -26,9 +26,15 @@ def parse_intent(text: str) -> str | None:
 
     text_lower = text.lower() # Convert to lowercase for case-insensitive matching
 
+    # --- Help intent ---
+    if "help" in text_lower or "what can you do" in text_lower:
+        return "help"
+
     # --- Note-related intents ---
     # Check for general "note" or "notes" keywords first.
     if "note" in text_lower or "notes" in text_lower:
+        if "search" in text_lower or "find" in text_lower:
+            return "search_notes"
         # Keywords for listing notes. Order matters: more specific ("list notes") before general ("note").
         if "list" in text_lower or \
            "show" in text_lower or \

--- a/personal_ai_agent/main.py
+++ b/personal_ai_agent/main.py
@@ -11,7 +11,7 @@ import os # Added for file operations
 from datetime import datetime # Added for timestamping meeting transcripts
 from audio_handler import speak, listen_and_transcribe
 from intent_parser import parse_intent
-from notes_module import save_note, list_notes, NOTES_DIR # Import NOTES_DIR
+from notes_module import save_note, list_notes, search_notes, NOTES_DIR # Import NOTES_DIR and search_notes
 from email_module import draft_email
 
 # --- Global Variables ---
@@ -114,6 +114,62 @@ def handle_list_notes_intent():
 
     if status_label: # Ensure GUI updates if it was a long list.
         status_label.winfo_toplevel().update_idletasks()
+
+
+def handle_search_notes_intent(command_text: str):
+    """Handles the 'search_notes' intent."""
+    global status_label
+
+    if status_label:
+        status_label.config(text="What keyword should I search for?")
+    speak("What keyword should I search for in your notes?")
+    query_text = listen_and_transcribe()
+    if not query_text or (isinstance(query_text, str) and query_text.startswith("Google STT error:")):
+        feedback = query_text or "I didn't catch the search keyword."
+        print(feedback)
+        speak(feedback)
+        if status_label:
+            status_label.config(text=feedback)
+        return
+
+    results = search_notes(query_text)
+    if results is None:
+        feedback = "Could not access the notes directory."
+    elif not results:
+        feedback = f"No notes found containing '{query_text}'."
+    else:
+        speak(f"I found {len(results)} notes containing {query_text}.")
+        display_names = [r.replace('.txt', '').replace('note_', '').replace('_', ' ') for r in results]
+        feedback = "\n".join(display_names[:5])
+        if len(display_names) > 5:
+            feedback += "\n(and more... see console for full list)"
+        for r in results[:3]:
+            try:
+                with open(os.path.join(NOTES_DIR, r), "r", encoding="utf-8") as f:
+                    first_line = f.readline().strip()
+                    if first_line:
+                        speak(f"Note snippet: {first_line[:50]}")
+            except Exception:
+                pass
+        print(f"Search results for '{query_text}': {results}")
+
+    print(feedback)
+    speak(feedback)
+    if status_label:
+        status_label.config(text=feedback)
+
+
+def handle_help_intent():
+    """Provides a short overview of supported commands."""
+    global status_label
+    help_text = (
+        "You can say: take a note, list notes, search notes, draft an email, "
+        "start meeting, stop meeting, or help."
+    )
+    print(help_text)
+    speak(help_text)
+    if status_label:
+        status_label.config(text=help_text)
 
 
 def handle_send_email_intent(command_text: str):
@@ -474,8 +530,13 @@ def on_record_button_pressed():
                     speak("Okay, I will draft an email.") 
                     handle_send_email_intent(transcribed_text)
                 elif intent == "list_notes":
-                    speak("Okay, I will list your notes.") 
+                    speak("Okay, I will list your notes.")
                     handle_list_notes_intent()
+                elif intent == "search_notes":
+                    speak("Searching your notes.")
+                    handle_search_notes_intent(transcribed_text)
+                elif intent == "help":
+                    handle_help_intent()
                 elif intent is not None: # An intent was parsed but not one of the above (and no meeting)
                     feedback = "I'm not sure how to help with that."
                     print(feedback)

--- a/personal_ai_agent/notes_module.py
+++ b/personal_ai_agent/notes_module.py
@@ -107,3 +107,40 @@ def list_notes() -> list[str] | None:
         # Catch any other unexpected errors.
         print(f"An unexpected error occurred while listing notes: {e_unexpected}")
         return None
+
+def search_notes(query: str) -> list[str] | None:
+    """Searches all notes for the given query string.
+
+    Args:
+        query: Keyword or phrase to search for.
+
+    Returns:
+        A list of note filenames that contain the query. Returns an empty list
+        if no matches are found. Returns None if the notes directory does not
+        exist or cannot be accessed.
+    """
+    if not os.path.exists(NOTES_DIR):
+        print(f"Error: Notes directory '{NOTES_DIR}' does not exist.")
+        return None
+
+    matches = []
+    try:
+        for filename in os.listdir(NOTES_DIR):
+            if filename.startswith("note_") and filename.endswith(".txt"):
+                filepath = os.path.join(NOTES_DIR, filename)
+                if os.path.isfile(filepath):
+                    try:
+                        with open(filepath, "r", encoding="utf-8") as f:
+                            contents = f.read().lower()
+                            if query.lower() in contents:
+                                matches.append(filename)
+                    except Exception as e_read:
+                        print(f"Error reading {filepath}: {e_read}")
+        if not matches:
+            print(f"No notes contain the query '{query}'.")
+            return []
+        print(f"Found {len(matches)} notes containing '{query}': {matches}")
+        return matches
+    except OSError as e_os:
+        print(f"Error searching notes directory: {e_os}")
+        return None

--- a/personal_ai_agent/tests/test_intent_parser.py
+++ b/personal_ai_agent/tests/test_intent_parser.py
@@ -1,0 +1,11 @@
+import builtins
+import os
+
+from intent_parser import parse_intent
+
+def test_parse_intent_search_notes():
+    assert parse_intent("search my notes for meeting") == "search_notes"
+
+
+def test_parse_intent_help():
+    assert parse_intent("help me") == "help"

--- a/personal_ai_agent/tests/test_notes_module.py
+++ b/personal_ai_agent/tests/test_notes_module.py
@@ -1,0 +1,21 @@
+import os
+import tempfile
+
+import notes_module
+
+
+def test_search_notes(tmp_path):
+    notes_dir = tmp_path / "notes"
+    notes_dir.mkdir()
+    # create two notes
+    (notes_dir / "note_1.txt").write_text("meeting agenda")
+    (notes_dir / "note_2.txt").write_text("shopping list")
+    # temporarily patch NOTES_DIR
+    old_dir = notes_module.NOTES_DIR
+    notes_module.NOTES_DIR = str(notes_dir)
+    try:
+        results = notes_module.search_notes("meeting")
+        assert len(results) == 1
+        assert results[0].endswith("note_1.txt")
+    finally:
+        notes_module.NOTES_DIR = old_dir


### PR DESCRIPTION
## Summary
- support new intents in `intent_parser` for searching notes and help
- implement `search_notes` helper in `notes_module`
- add handlers for searching notes and help in `main.py`
- document the new voice commands in README
- add tests for new logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862e84c97848320a5024fe5e942e31c